### PR TITLE
Add an option to not log anything if no keys are found

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ It can be annoying be forced to skip the decryption all the time you launch a co
 cryptoEnv -t
 ```
 
+## Skip the log when needed
+
+In some cases, the console.log that tells about the encrypted keys can create problems because the output is used as is. For example, flattening a contract with Hardhat.
+
+To avoid seeing the log, you can add the options `noLogsIfNoKeys` like
+
+```javascript
+require("cryptoenv").parse({
+  noLogsIfNoKeys: true,
+});
+```
+
+Alternatively, you can set the variable `NO_LOGS_IF_NO_KEYS` in the environment.~~~~
+
 ## About security
 
 CryptoEnv uses the package @secrez/crypto from Secrez https://github.com/secrez/secrez

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ require("cryptoenv").parse({
 });
 ```
 
-Alternatively, you can set the variable `NO_LOGS_IF_NO_KEYS` in the environment.~~~~
+Alternatively, you can set the variable `NO_LOGS_IF_NO_KEYS` in the environment.
 
 ## About security
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Options:
 
 ## History
 
+**0.1.7**
+
+- Add `noLogsIfNoKeys` options to skip any logging test if no keys are found
+
 **0.1.6**
 
 - Improve message when keys exist but are disabled

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Options:
 
 **0.1.7**
 
-- Add `noLogsIfNoKeys` options to skip any logging test if no keys are found
+- Add `noLogsIfNoKeys` options in `.parse` to skip any logging test if no keys are found
+- Add same skip if an ENV variable `NO_LOGS_IF_NO_KEYS` is set
 
 **0.1.6**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptoenv",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Manage encrypted env variables",
   "homepage": "https://github.com/secrez/cryptoenv#readme",
   "bugs": {

--- a/src/CryptoEnv.js
+++ b/src/CryptoEnv.js
@@ -16,6 +16,12 @@ class CryptoEnv {
     }
   }
 
+  consoleInfo(force, ...params) {
+    if (force || !this.options.noLogsIfNoKeys) {
+      console.info(...params);
+    }
+  }
+
   async run() {
     const { newKey, list, toggle } = this.options;
     if (newKey) {
@@ -87,14 +93,14 @@ class CryptoEnv {
       if (asIs) {
         return { variables, env };
       } else {
-        console.info("Active env variables:");
-        console.info(Object.keys(variables).join("\n"));
+        this.consoleInfo(true, "Active env variables:");
+        this.consoleInfo(true, Object.keys(variables).join("\n"));
       }
     } else {
       if (asIs) {
         return { variables: {}, env: [] };
       }
-      console.info("No encrypted env variables, yet");
+      this.consoleInfo(true, "No encrypted env variables, yet");
     }
   }
 
@@ -141,7 +147,7 @@ class CryptoEnv {
       },
     ]);
     await this.encryptAndSave(variable, password);
-    console.info("Keys successfully stored");
+    this.consoleInfo(true, "Keys successfully stored");
   }
 
   async encryptAndSave(variable, password) {
@@ -187,27 +193,32 @@ class CryptoEnv {
     }
     if (Object.keys(this.keys).length === 0) {
       if (this.hasDisabled()) {
-        console.info(
+        this.consoleInfo(
+          false,
           chalk.grey(
             `CryptoEnv > some encrypted keys are disabled. Run "cryptoEnv -t" to enable them`
           )
         );
       } else {
-        console.info(chalk.grey(`CryptoEnv > no encrypted keys found`));
+        this.consoleInfo(
+          false,
+          chalk.grey(`CryptoEnv > no encrypted keys found`)
+        );
       }
       process.env.__decryptionAlreadyDone__ = "TRUE";
       return;
     }
     if (!password) {
       const prompt = require("prompt-sync")({});
-      console.info(
+      this.consoleInfo(
+        true,
         chalk.green(
           "CryptoEnv > Type your password to decrypt the env, or press enter to skip it"
         )
       );
       password = prompt.hide();
       if (!password) {
-        console.info(chalk.grey("CryptoEnv > decryption skipped"));
+        this.consoleInfo(true, chalk.grey("CryptoEnv > decryption skipped"));
         process.env.__decryptionAlreadyDone__ = "TRUE";
         return;
       }
@@ -225,22 +236,27 @@ class CryptoEnv {
         );
         found++;
       } catch (e) {
-        console.info(chalk.red("Wrong password"));
+        this.consoleInfo(true, chalk.red("Wrong password"));
         process.exit(1);
       }
     }
     if (found) {
-      console.info(
+      this.consoleInfo(
+        true,
         chalk.green(`CryptoEnv > ${found} key${found > 1 ? "s" : ""} decrypted`)
       );
     } else if (this.hasDisabled()) {
-      console.info(
+      this.consoleInfo(
         chalk.grey(
+          false,
           `CryptoEnv > some encrypted keys are disabled. Run "cryptoEnv -t" to enable them`
         )
       );
     } else {
-      console.info(chalk.grey(`CryptoEnv > no encrypted keys found`));
+      this.consoleInfo(
+        false,
+        chalk.grey(`CryptoEnv > no encrypted keys found`)
+      );
     }
     process.env.__decryptionAlreadyDone__ = "TRUE";
   }

--- a/src/CryptoEnv.js
+++ b/src/CryptoEnv.js
@@ -17,7 +17,9 @@ class CryptoEnv {
   }
 
   consoleInfo(force, ...params) {
-    if (force || !this.options.noLogsIfNoKeys) {
+    const noLogs =
+      !!this.options.noLogsIfNoKeys || !!process.env.NO_LOGS_IF_NO_KEYS;
+    if (force || !noLogs) {
       console.info(...params);
     }
   }

--- a/test/CryptoEnv.test.js
+++ b/test/CryptoEnv.test.js
@@ -120,7 +120,7 @@ describe("CryptoEnv", async function () {
     });
   });
 
-  describe("toggle", async function () {
+  describe.only("toggle", async function () {
     it("should toggle the variables", async function () {
       let cryptoEnv = new CryptoEnv({ envPath });
       await cryptoEnv.toggle();


### PR DESCRIPTION
In some case, the log saying that no keys are found, can create problems. For example, flattening a smart contract.

