### PR TITLE
Version 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ In the case above, in your `.env` file you will have something like
 cryptoEnv_OWNER_KEY=vnJSFJ5E4ZHT1hd8tmMduc1HbQqmkXE/dReUmjHFvud5DsquU6VrOZ+1K3wFj2wYIc8KaClbZWlAtG5HuE2QfE1hx3snHBpz0sqkhfM2v8gTTR77RnLZ23GcKYTGa2G5frcuECngSpE=
 ```
 
+Starting from v0.2.0, you can use different passwords to encrypt the different variables.
+This allows a team to share an encrypted env, knowing that team members can access only their own keys.
+
 ### In your node app
 
 Install it as usual
@@ -79,7 +82,7 @@ For example, when you run a script with Hardhat, it first runs a first process t
 
 ### Multiple apps
 
-Sometimes you have in a repo multiple apps and it is possible that you do not want to share data with them. You can filter your variables using RegExp like here:
+Sometimes you have in a repo multiple apps, and it is possible that you do not want to share data with them. You can filter your variables using RegExp like here:
 
 ```javascript
 require("cryptoenv").parse(/^hardhat/);
@@ -101,7 +104,18 @@ require("cryptoenv").parse(() => {
 });
 ```
 
-(notice that Hardhat does not set the NODE_ENV variable during tests)
+Notice that Hardhat does not set the NODE_ENV variable during tests, you must set it yourself.
+
+You can also mix the settings, like
+
+```javascript
+const words = ["home", "office", "street"];
+require("cryptoenv").parse({ alwaysLog: true }, (e) => words.includes(e));
+```
+
+You can also decide to use different prefix for the encrypted variable. By default, the prefix is `cryptoEnv_`, but you can change it with the option `prefix`.
+
+Finally, if your variables are in a file different than `.env` in the root of the repo, you can specify the full path with the option `--env-path` launching the CLI.~~~~
 
 ## Enable/disable
 
@@ -111,19 +125,21 @@ It can be annoying be forced to skip the decryption all the time you launch a co
 cryptoEnv -t
 ```
 
-## Skip the log when needed
+Since 0.2.0, `--toggle` is deprecated. Better to use `--enable` and `--disable` to explicit call for a specific action.
 
-In some cases, the console.log that tells about the encrypted keys can create problems because the output is used as is. For example, flattening a contract with Hardhat.
+## Show the log even when not needed
 
-To avoid seeing the log, you can add the options `noLogsIfNoKeys` like
+The console.log that tells about the encrypted keys can create problems because the output is used as is. For this reason, starting from version 0.2.0, by default, cryptoenv returns a feedback only if it finds active encrypted variables in `.env`.
+
+If you want that the log is showed anytime, use the options `alwaysLog`, like
 
 ```javascript
 require("cryptoenv").parse({
-  noLogsIfNoKeys: true,
+  alwaysLog: true,
 });
 ```
 
-Alternatively, you can set the variable `NO_LOGS_IF_NO_KEYS` in the environment.
+Alternatively, you can set the variable `ALWAYS_LOG` in the environment.
 
 **No logs at all?**
 
@@ -135,22 +151,53 @@ CryptoEnv uses the package @secrez/crypto from Secrez https://github.com/secrez/
 
 ## Help
 
-If you run cryptoenv without parameters, a help screen will be displayed:
+If you run cryptoenv without parameters, a help screen like the one below will be displayed:
 
 ```
-Welcome to CryptoEnv v0.1.3
+Welcome to CryptoEnv v0.2.0
 Manage encrypted env variable in CLI applications like eating candies
 
 For help look at
 https://github.com/secrez/cryptoenv#readme
 
 Options:
-  -n, --new  [key name]       Add a new key
-  -l, --list                  List the keys' names
-  -t, --toggle                Toggle enabled/disabled keys
+  -n, --new -key [key name]       Add a new key
+  -l, --list                      List the keys' names
+  -e, --enable                    Enables the keys
+  -d, --disable                   Disables the keys
+  -t, --toggle                    Toggle enabled/disabled keys
+  -p, --env-path [env file path]  Specifies where the env file path
+  -f, --force-previous-pwd        Forces to use the same password
+                                    used previously (like until v0.1.8)
+  -u, --no-optimization           Skips the .env optimization, that removes
+                                    empty rows
+
+Notes:
+  --e has priority on --disable and --toggle
+  --disable has priority on --toggle
+  if --list is set, -e, -d or -t are ignored
+
+Example;
+  cryptoenv -n MAINNET_PK              Add the new key called MAINNET_PK
+  cryptoenv -n MAINNET_PK -f           Add the new key called MAINNET_PK forcing to
+                                         use the same password used previously
+  cryptoenv -lp \`pwd\`/../.prod-env   Lists the keys in the .prod-env file
 ```
 
 ## History
+
+**0.2.0 - Breaking changes**
+
+- Reverse the behavior. If not specified, it returns feedback only if there are encrypted variables in the env
+- Add `alwaysLog` option and `ALWAYS_LOG` env variable to show the log all the time
+- Ignores previous options `noLogs` and `noLogsIfNoKeys`
+- Explicit `filter` option to filter the variables
+- The CLI `--toggle` option returns an explanation feedback
+- The CLI `--list` option returns also the not-active variables
+- Calling `cryptoenv` without options shows the help
+- Supports different passwords for different variables. When decrypting, it decrypts only the keys that were encrypted with the specified password
+- Creating a new key it optimizes the .env file removing empty rows except if:
+- The CLI `--no-optimization` skips the `.env` optimization
 
 **0.1.8**
 
@@ -180,3 +227,7 @@ Options:
 ## License
 
 MIT — enjoy it :-)
+
+```
+
+```

--- a/bin/cryptoenv.js
+++ b/bin/cryptoenv.js
@@ -1,23 +1,79 @@
 #!/usr/bin/env node
-
-const pkg = require("../package");
+const commandLineArgs = require("command-line-args");
+const pkg = require("../package.json");
 const CryptoEnv = require("../src/CryptoEnv");
 
-const [, , cmd, param] = process.argv;
+const optionDefinitions = [
+  {
+    name: "help",
+    alias: "h",
+    type: Boolean,
+  },
+  {
+    name: "new-key",
+    alias: "n",
+    type: String,
+  },
+  {
+    name: "list",
+    alias: "l",
+    type: Boolean,
+  },
+  {
+    name: "enable",
+    alias: "e",
+    type: Boolean,
+  },
+  {
+    name: "disable",
+    alias: "d",
+    type: Boolean,
+  },
+  {
+    name: "toggle",
+    alias: "t",
+    type: Boolean,
+  },
+  {
+    name: "env-path",
+    alias: "p",
+    type: String,
+  },
+  {
+    name: "check-previous",
+    alias: "c",
+    type: Boolean,
+  },
+  {
+    name: "no-optimization",
+    alias: "u",
+    type: Boolean,
+  },
+];
 
-const options = {};
-
-if ((cmd === "--new" || cmd === "-n") && param.length > 0) {
-  options.newKey = param.toUpperCase();
-} else if (cmd === "--toggle" || cmd === "-t") {
-  options.toggle = true;
-} else if (cmd === "--list" || cmd === "-l") {
-  options.list = true;
+function error(message) {
+  if (!Array.isArray(message)) {
+    message = [message];
+  }
+  console.error(message[0]);
+  if (message[1]) {
+    console.info(message[1]);
+  }
+  /*eslint-disable-next-line*/
+  process.exit(1);
 }
 
-if (Object.keys(options).length === 0) {
-  console.info(`
+let options = {};
+try {
+  options = commandLineArgs(optionDefinitions, {
+    camelCase: true,
+  });
+} catch (e) {
+  error(e.message, "Launch cryptoenv -h for help");
+}
 
+if (options.help || Object.keys(options).length === 0) {
+  console.info(`
 Welcome to CryptoEnv v${pkg.version}
 Manage encrypted env variable in CLI applications like eating candies
 
@@ -25,14 +81,33 @@ For help look at
 https://github.com/secrez/cryptoenv#readme
 
 Options:
-  -n, --new  [key name]       Add a new key
-  -l, --list                  List the keys' names
-  -t, --toggle                Toggle enabled/disabled keys
-`);
+  -n, --new -key [key name]       Add a new key
+  -l, --list                      List the keys' names
+  -e, --enable                    Enables the keys
+  -d, --disable                   Disables the keys
+  -t, --toggle                    Toggle enabled/disabled keys
+  -p, --env-path [env file path]  Specifies where the env file path
+  -f, --force-previous-pwd        Forces to use the same password
+                                    used previously (like until v0.1.8)
+  -u, --no-optimization           Skips the .env optimization, that removes
+                                    empty rows
 
+Notes:
+  --e has priority on --disable and --toggle
+  --disable has priority on --toggle
+  if --list is set, -e, -d or -t are ignored
+
+Example;
+  cryptoenv -n MAINNET_PK              Add the new key called MAINNET_PK
+  cryptoenv -n MAINNET_PK -f           Add the new key called MAINNET_PK forcing to
+                                         use the same password used previously
+  cryptoenv -lp \`pwd\`/../.prod-env   Lists the keys in the .prod-env file
+`);
   // eslint-disable-next-line no-process-exit
   process.exit(0);
 }
+
+options.isCLI = true;
 
 async function main() {
   options.cli = true;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "all-tests": "find test/** -name '*.test.js' | xargs ./node_modules/.bin/mocha -R spec",
     "test-only": "cross-env NODE_ENV=test ./node_modules/.bin/mocha test/*.test.js --exit",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov --reporter=text ./node_modules/.bin/_mocha test/*.test.js --exit",
-    "posttest": "nyc check-coverage --statements 55 --branches 45 --functions 55 --lines 55",
+    "posttest": "nyc check-coverage --statements 90 --branches 75 --functions 100 --lines 90",
     "postinstall": "./post-install.sh",
     "prepare": "husky install",
     "format": "npx prettier --write ."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cryptoenv",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "Manage encrypted env variables",
   "homepage": "https://github.com/secrez/cryptoenv#readme",
   "bugs": {

--- a/test/CryptoEnv.test.js
+++ b/test/CryptoEnv.test.js
@@ -26,7 +26,7 @@ describe("CryptoEnv", async function () {
 
   describe("list", async function () {
     it("should return the env plus the existing encrypted variables", async function () {
-      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ envPath, noLogs: true });
 
       const { variables } = cryptoEnv.list(true);
       expect(Object.keys(variables).length).equal(2);
@@ -55,7 +55,7 @@ describe("CryptoEnv", async function () {
     it("should encrypt a new variable and save it in .env", async function () {
       let newKey = "privateKey";
       let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
-      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true, newKey });
+      let cryptoEnv = new CryptoEnv({ envPath, noLogs: true, newKey });
       await cryptoEnv.encryptAndSave(value1, password);
       const { variables } = cryptoEnv.list(true);
       expect(Object.keys(variables).length).equal(3);
@@ -68,7 +68,7 @@ describe("CryptoEnv", async function () {
     it("should replace an existing variable and save it in .env", async function () {
       let newKey = "myKey";
       let value1 = "workdansdaBANK9987";
-      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true, newKey });
+      let cryptoEnv = new CryptoEnv({ envPath, noLogs: true, newKey });
       await cryptoEnv.encryptAndSave(value1, password);
       const { variables } = cryptoEnv.list(true);
       expect(Object.keys(variables).length).equal(2);
@@ -83,8 +83,8 @@ describe("CryptoEnv", async function () {
       let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
       let cryptoEnv = new CryptoEnv({
         envPath,
-        skipConsole: true,
         newKey,
+        alwaysLog: true,
         forcePreviousPwd: true,
       });
       await assertThrowsMessage(
@@ -99,7 +99,7 @@ describe("CryptoEnv", async function () {
       let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
       let cryptoEnv = new CryptoEnv({
         envPath: envPath + 2,
-        skipConsole: true,
+        noLogs: true,
         newKey,
         forcePreviousPwd: true,
       });
@@ -116,7 +116,7 @@ describe("CryptoEnv", async function () {
     it("should parse the .env file and decrypt the variables", async function () {
       delete process.env.myKey;
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ noLogs: true });
       cryptoEnv.parse(undefined, password);
       expect(process.env.myKey).equal(value);
     });
@@ -125,7 +125,7 @@ describe("CryptoEnv", async function () {
       delete process.env.myKey;
       delete process.env.myOtherKey;
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ noLogs: true });
       cryptoEnv.parse(/argoPlan/, password);
       expect(process.env.myKey).equal(undefined);
       delete process.env.__decryptionAlreadyDone__;
@@ -137,7 +137,7 @@ describe("CryptoEnv", async function () {
     it("should parse with a filter (regex) and some option", async function () {
       delete process.env.myOtherKey;
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ noLogs: true });
       cryptoEnv.parse({ alwaysLog: true }, /Other/, password2);
       expect(cryptoEnv.options.alwaysLog).equal(true);
       expect(process.env.myOtherKey).equal(value2);
@@ -147,7 +147,7 @@ describe("CryptoEnv", async function () {
       delete process.env.myKey;
       process.env.nodeENV = "test";
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ noLogs: true });
       cryptoEnv.parse(() => process.env.nodeENV !== "test", password);
       expect(process.env.myKey).equal(undefined);
       delete process.env.__decryptionAlreadyDone__;
@@ -160,7 +160,7 @@ describe("CryptoEnv", async function () {
       this.timeout(60000);
       // to verify it manually
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      let cryptoEnv = new CryptoEnv({ noLogs: true });
       cryptoEnv.parse();
       expect(process.env.myKey, value);
     });
@@ -170,7 +170,8 @@ describe("CryptoEnv", async function () {
     it("should toggle the variables", async function () {
       let cryptoEnv = new CryptoEnv({
         envPath,
-        skipConsole: true,
+        noLogs: true,
+        listOnlyActive: true,
       });
       await cryptoEnv.toggle();
       expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
@@ -181,10 +182,11 @@ describe("CryptoEnv", async function () {
 
   describe("disable", async function () {
     it("should disable the variables", async function () {
+      process.env.NO_LOGS = true;
       let cryptoEnv = new CryptoEnv({
         envPath,
-        skipConsole: true,
         disable: true,
+        listOnlyActive: true,
       });
       await cryptoEnv.toggle();
       expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
@@ -195,14 +197,15 @@ describe("CryptoEnv", async function () {
     it("should enable the variables", async function () {
       let cryptoEnv = new CryptoEnv({
         envPath,
-        skipConsole: true,
+        noLogs: true,
         disable: true,
+        listOnlyActive: true,
       });
       await cryptoEnv.toggle();
       expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
       cryptoEnv = new CryptoEnv({
         envPath,
-        skipConsole: true,
+        noLogs: true,
         enable: true,
       });
       await cryptoEnv.toggle();

--- a/test/CryptoEnv.test.js
+++ b/test/CryptoEnv.test.js
@@ -7,14 +7,17 @@ const { assertThrowsMessage } = require("./helpers");
 describe("CryptoEnv", async function () {
   let tmpPath = path.resolve(__dirname, "../tmp/test");
   let envPath = path.join(tmpPath, ".env");
-  let password = "some-very-strong-password";
   let value = "8s8s8s8s87w7w7wydydydyd6d6d6d6";
+  let password = "some-very-strong-password";
+  let value2 = "9s9s9s9sueueueywywywywhdhd";
+  let password2 = "some-other-password";
 
   before(async function () {});
 
   beforeEach(async function () {
     await fs.emptyDir(tmpPath);
     await fs.copy(path.resolve(__dirname, "fixtures/.env"), envPath);
+    delete process.env.__decryptionAlreadyDone__;
   });
 
   after(async function () {
@@ -23,10 +26,10 @@ describe("CryptoEnv", async function () {
 
   describe("list", async function () {
     it("should return the env plus the existing encrypted variables", async function () {
-      let cryptoEnv = new CryptoEnv({ envPath });
+      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true });
 
       const { variables } = cryptoEnv.list(true);
-      expect(Object.keys(variables).length).equal(1);
+      expect(Object.keys(variables).length).equal(2);
       expect(variables.myKey).equal(
         "BqeLHsJps3fw484ekR2ynDSLmwt52LfFPV67nVWPo6zjDmQ3u4TMJ2oGqm35VYI+Ejr7UMnZHWuOUKIXVJqsr+3trn2vFg=="
       );
@@ -36,6 +39,15 @@ describe("CryptoEnv", async function () {
           CryptoEnv.Crypto.SHA3(password)
         )
       ).equal(value);
+      expect(variables.myOtherKey).equal(
+        "yWdotYMMgZioXDW95yOd0MMW1duInmuKbKqdElNBruAP4+dv5jYeLY4ADlzgeCSVPim2VPz3u6tC3aGGTm7LViLc"
+      );
+      expect(
+        CryptoEnv.Crypto.decrypt(
+          variables.myOtherKey,
+          CryptoEnv.Crypto.SHA3(password2)
+        )
+      ).equal(value2);
     });
   });
 
@@ -43,10 +55,10 @@ describe("CryptoEnv", async function () {
     it("should encrypt a new variable and save it in .env", async function () {
       let newKey = "privateKey";
       let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
-      let cryptoEnv = new CryptoEnv({ envPath, newKey });
+      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true, newKey });
       await cryptoEnv.encryptAndSave(value1, password);
       const { variables } = cryptoEnv.list(true);
-      expect(Object.keys(variables).length).equal(2);
+      expect(Object.keys(variables).length).equal(3);
       expect(variables.myKey).equal(
         "BqeLHsJps3fw484ekR2ynDSLmwt52LfFPV67nVWPo6zjDmQ3u4TMJ2oGqm35VYI+Ejr7UMnZHWuOUKIXVJqsr+3trn2vFg=="
       );
@@ -56,24 +68,47 @@ describe("CryptoEnv", async function () {
     it("should replace an existing variable and save it in .env", async function () {
       let newKey = "myKey";
       let value1 = "workdansdaBANK9987";
-      let cryptoEnv = new CryptoEnv({ envPath, newKey });
+      let cryptoEnv = new CryptoEnv({ envPath, skipConsole: true, newKey });
       await cryptoEnv.encryptAndSave(value1, password);
       const { variables } = cryptoEnv.list(true);
-      expect(Object.keys(variables).length).equal(1);
+      expect(Object.keys(variables).length).equal(2);
       expect(variables.myKey).not.equal(
         "BqeLHsJps3fw484ekR2ynDSLmwt52LfFPV67nVWPo6zjDmQ3u4TMJ2oGqm35VYI+Ejr7UMnZHWuOUKIXVJqsr+3trn2vFg=="
       );
       expect(!!variables[newKey]).equal(true);
     });
 
-    it("should throw if using another password", async function () {
+    it("should throw if using another password if forcePreviousPwd=true", async function () {
       let newKey = "privateKey";
       let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
-      let cryptoEnv = new CryptoEnv({ envPath, newKey });
-      assertThrowsMessage(
+      let cryptoEnv = new CryptoEnv({
+        envPath,
+        skipConsole: true,
+        newKey,
+        forcePreviousPwd: true,
+      });
+      await assertThrowsMessage(
         cryptoEnv.encryptAndSave(value1, "a-new-strong-password"),
         "This is not the password used in the past"
       );
+    });
+
+    it("should not throw if using same password and forcePreviousPwd=true", async function () {
+      await fs.copy(path.resolve(__dirname, "fixtures/.env2"), envPath + 2);
+      let newKey = "privateKey";
+      let value1 = "7fys8f7ywbfwbyef8sbfs8dfysd8cysdchsdcysc";
+      let cryptoEnv = new CryptoEnv({
+        envPath: envPath + 2,
+        skipConsole: true,
+        newKey,
+        forcePreviousPwd: true,
+      });
+      try {
+        cryptoEnv.encryptAndSave(value1, password);
+        assert("It did not throw");
+      } catch (e) {
+        expect(e.message).equal("Whoops");
+      }
     });
   });
 
@@ -81,27 +116,38 @@ describe("CryptoEnv", async function () {
     it("should parse the .env file and decrypt the variables", async function () {
       delete process.env.myKey;
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv();
+      let cryptoEnv = new CryptoEnv({ skipConsole: true });
       cryptoEnv.parse(undefined, password);
       expect(process.env.myKey).equal(value);
     });
 
     it("should parse with a filter (regex)", async function () {
       delete process.env.myKey;
+      delete process.env.myOtherKey;
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv();
+      let cryptoEnv = new CryptoEnv({ skipConsole: true });
       cryptoEnv.parse(/argoPlan/, password);
       expect(process.env.myKey).equal(undefined);
       delete process.env.__decryptionAlreadyDone__;
       cryptoEnv.parse(/key/i, password);
       expect(process.env.myKey).equal(value);
+      expect(process.env.myOtherKey).equal(undefined);
+    });
+
+    it("should parse with a filter (regex) and some option", async function () {
+      delete process.env.myOtherKey;
+      require("dotenv").config({ path: envPath });
+      let cryptoEnv = new CryptoEnv({ skipConsole: true });
+      cryptoEnv.parse({ alwaysLog: true }, /Other/, password2);
+      expect(cryptoEnv.options.alwaysLog).equal(true);
+      expect(process.env.myOtherKey).equal(value2);
     });
 
     it("should parse with a filter (function)", async function () {
       delete process.env.myKey;
       process.env.nodeENV = "test";
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv();
+      let cryptoEnv = new CryptoEnv({ skipConsole: true });
       cryptoEnv.parse(() => process.env.nodeENV !== "test", password);
       expect(process.env.myKey).equal(undefined);
       delete process.env.__decryptionAlreadyDone__;
@@ -114,7 +160,7 @@ describe("CryptoEnv", async function () {
       this.timeout(60000);
       // to verify it manually
       require("dotenv").config({ path: envPath });
-      let cryptoEnv = new CryptoEnv();
+      let cryptoEnv = new CryptoEnv({ skipConsole: true });
       cryptoEnv.parse();
       expect(process.env.myKey, value);
     });
@@ -122,15 +168,45 @@ describe("CryptoEnv", async function () {
 
   describe("toggle", async function () {
     it("should toggle the variables", async function () {
-      let cryptoEnv = new CryptoEnv({ envPath });
+      let cryptoEnv = new CryptoEnv({
+        envPath,
+        skipConsole: true,
+      });
       await cryptoEnv.toggle();
       expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
-      // cryptoEnv.parse()
-      // console.log(999)
-      // cryptoEnv.parse({noLogsIfNoKeys: true})
-      // console.log(999)
       await cryptoEnv.toggle();
-      expect(Object.keys(cryptoEnv.list(true).variables).length).equal(1);
+      expect(Object.keys(cryptoEnv.list(true).variables).length).equal(2);
+    });
+  });
+
+  describe("disable", async function () {
+    it("should disable the variables", async function () {
+      let cryptoEnv = new CryptoEnv({
+        envPath,
+        skipConsole: true,
+        disable: true,
+      });
+      await cryptoEnv.toggle();
+      expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
+    });
+  });
+
+  describe("enable", async function () {
+    it("should enable the variables", async function () {
+      let cryptoEnv = new CryptoEnv({
+        envPath,
+        skipConsole: true,
+        disable: true,
+      });
+      await cryptoEnv.toggle();
+      expect(Object.keys(cryptoEnv.list(true).variables).length).equal(0);
+      cryptoEnv = new CryptoEnv({
+        envPath,
+        skipConsole: true,
+        enable: true,
+      });
+      await cryptoEnv.toggle();
+      expect(Object.keys(cryptoEnv.list(true).variables).length).equal(2);
     });
   });
 });

--- a/test/fixtures/.env2
+++ b/test/fixtures/.env2
@@ -1,0 +1,1 @@
+cryptoEnv_myKey=BqeLHsJps3fw484ekR2ynDSLmwt52LfFPV67nVWPo6zjDmQ3u4TMJ2oGqm35VYI+Ejr7UMnZHWuOUKIXVJqsr+3trn2vFg==


### PR DESCRIPTION

- Reverse the behavior. If not specified, it returns feedback only if there are encrypted variables in the env
- Add `alwaysLog` option and `ALWAYS_LOG` env variable to show the log all the time, disabling the previous option `noLogsIfNoKeys`, which was forcing the opposite behavior
- The CLI `--toggle` option returns an explanation feedback
- The CLI `--list` option returns also the not-active variables
- Calling `cryptoenv` without options shows the help
- Supports different passwords for different variables. When decrypting, it decrypts only the keys that were encrypted with the specified password
- Creating a new key it optimizes the .env file removing empty rows except if:
- The CLI `--no-optimization` skips the `.env` optimization
